### PR TITLE
Pl/fix eliminate dead code

### DIFF
--- a/core/core.stanza
+++ b/core/core.stanza
@@ -1152,7 +1152,7 @@ lostanza defn set-mark (heap:ptr<Heap>, p:ptr<?>) -> ref<False> :
   val address = bit-address(heap, index)
   [address] = [address] | bit-mask(index)
   ;No meaningful return value.
-  return 0
+  return false
 
 ;Marks the given heap pointer in the heap's bitset.
 ;Returns a non-zero value if the pointer was previously marked.


### PR DESCRIPTION
Hi Jonathan,

I made some modifications to your fix, but don't have the original test case that was failing in your design. Can you review the changes, and also test to see whether the new changes pass your original test case?

Changes:
1) To avoid creating a huge table, defs and uses are calculated for a single ETExp at a time, instead of for the entire package.
2) The collect-defs and collect-uses function was merged into one.
3) The unused `uses` argument was removed from `eliminate-in-item`.
4) Removed one indentation level by removing nested let loop in `eliminate-in-item`. 